### PR TITLE
Updated version to 2.0.0

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "slug": "CharredDesert",
   "name": "CharredDesert",
-  "version": "1.3.1",
+  "version": "2.0.0",
   "license": "CC0-1.0",
   "author": "Jerry Sievert",
   "authorEmail": "contact@svmodular.com",


### PR DESCRIPTION
The current plugin won't work for Rack 2. Updating the version to 2.0.0 builds just fine.